### PR TITLE
Add argcomplete to install_requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Some example commands:
 
 1. Install bsed
     - `pip3 install --upgrade bsed`
-2. Install argcomplete
-    - `pip3 install argcomplete`
-3. Register bsed for autocompletion
+2. Register bsed for autocompletion
     - `echo eval "$(register-python-argcomplete bsed)" >> ~/.bash_profile`
 
 Open a new shell (or run `source ~/.bash_profile`). 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
             'bsed = bsed.interpreter:main'
         ]
     },
+    install_requires=['argcomplete'],
     include_package_data=True,
     python_requires='>3.1.0',
 )


### PR DESCRIPTION
Add `argcomplete` to the package requirements, so pip will install it automatically upon `pip install bsed`.
https://packaging.python.org/discussions/install-requires-vs-requirements/