### PR TITLE
escape special character

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ applying a command to an entire input stream or open file.
 
 Some example commands:
 
-- `bsed contacts.csv delete lines containing 'myemail@website.com'`
+- `bsed contacts.csv delete lines containing 'myemail\@website.com'`
 - `bsed giant_malformatted.json replace '\'' with '\"' | bsed replace 'True' with 'true' | bsed replace 'False' with 
 'false'` 
 - `bsed file.txt append 'Yahoo' with '!'`


### PR DESCRIPTION
The first example didn't work without escaping the '@' character.
Probably other commands should have their strings escaped in case of containing special characters, right?